### PR TITLE
feat: support item discounts and negative prices

### DIFF
--- a/src/Components/EditItemModal.jsx
+++ b/src/Components/EditItemModal.jsx
@@ -5,7 +5,9 @@ const EditItemModal = ({ isOpen, onClose, item, onSave }) => {
   const [formData, setFormData] = useState({
     name: '',
     price: '',
-    quantity: 1
+    quantity: 1,
+    discount: 0,
+    discountType: 'flat'
   });
   const nameInputRef = useRef(null);
 
@@ -15,7 +17,9 @@ const EditItemModal = ({ isOpen, onClose, item, onSave }) => {
       setFormData({
         name: item.name,
         price: item.price,
-        quantity: item.quantity
+        quantity: item.quantity,
+        discount: item.discount || 0,
+        discountType: item.discountType || 'flat'
       });
       
       // Focus the name input when the modal opens
@@ -35,11 +39,13 @@ const EditItemModal = ({ isOpen, onClose, item, onSave }) => {
 
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (formData.name.trim() && Number(formData.price) > 0) {
+    if (formData.name.trim() && formData.price !== '' && !isNaN(Number(formData.price))) {
       onSave(item.id, {
         name: formData.name.trim(),
         price: parseFloat(formData.price),
-        quantity: parseInt(formData.quantity) || 1
+        quantity: parseInt(formData.quantity) || 1,
+        discount: parseFloat(formData.discount) || 0,
+        discountType: formData.discountType
       });
       onClose();
     }
@@ -77,7 +83,6 @@ const EditItemModal = ({ isOpen, onClose, item, onSave }) => {
             id="itemPrice"
             name="price"
             type="number"
-            min="0"
             step="0.01"
             value={formData.price}
             onChange={handleChange}
@@ -89,6 +94,33 @@ const EditItemModal = ({ isOpen, onClose, item, onSave }) => {
             placeholder="0.00"
             required
           />
+        </div>
+
+        <div className="mb-4">
+          <label htmlFor="itemDiscount" className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+            Discount
+          </label>
+          <div className="flex space-x-2">
+            <input
+              id="itemDiscount"
+              name="discount"
+              type="number"
+              step="0.01"
+              value={formData.discount}
+              onChange={handleChange}
+              className="w-full p-2 border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-700 text-zinc-800 dark:text-white rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-1 dark:focus-visible:ring-blue-400 dark:focus-visible:ring-offset-zinc-800 transition-colors"
+              placeholder="0.00"
+            />
+            <select
+              name="discountType"
+              value={formData.discountType}
+              onChange={handleChange}
+              className="p-2 border border-zinc-300 dark:border-zinc-600 bg-white dark:bg-zinc-700 text-zinc-800 dark:text-white rounded-md focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-600 focus-visible:ring-offset-1 dark:focus-visible:ring-blue-400 dark:focus-visible:ring-offset-zinc-800 transition-colors"
+            >
+              <option value="flat">Flat</option>
+              <option value="percentage">%</option>
+            </select>
+          </div>
         </div>
 
         <div className="mb-4">

--- a/src/Components/ItemAssignment.jsx
+++ b/src/Components/ItemAssignment.jsx
@@ -1,5 +1,5 @@
 import { useMemo, memo, useCallback, useState } from 'react';
-import useBillStore, { useBillPersons, useBillItems, SPLIT_TYPES } from '../billStore';
+import useBillStore, { useBillPersons, useBillItems, SPLIT_TYPES, getDiscountedItemPrice } from '../billStore';
 import { useFormatCurrency } from '../currencyStore';
 import { useShallow } from 'zustand/shallow';
 import { Card, Button, ToggleButton, SelectAllButton } from '../ui/components';
@@ -9,7 +9,7 @@ import PassAndSplitButton from './PassAndSplit/PassAndSplitButton';
 
 // Individual Item Card component
 const ItemCard = memo(({ 
-  item, 
+  item,
   people, 
   onTogglePerson, 
   formatCurrency, 
@@ -97,6 +97,8 @@ const ItemCard = memo(({
     onTogglePerson('none', item.id);
   }, [onTogglePerson, item.id]);
   
+  const itemPrice = useMemo(() => getDiscountedItemPrice(item), [item]);
+
   return (
     <Card className="mb-4">
       <div className="mb-3 flex justify-between">
@@ -104,7 +106,7 @@ const ItemCard = memo(({
           <h3 className="text-lg font-medium text-zinc-800 dark:text-white transition-colors">{item.name}</h3>
           <p className="text-sm text-zinc-600 dark:text-zinc-400 transition-colors">
             {item.quantity > 1 ? `${item.quantity} × ` : ''}
-            {formatCurrency(parseFloat(item.price))}
+            {formatCurrency(itemPrice)}
           </p>
         </div>
         <button 
@@ -168,7 +170,7 @@ const ItemCard = memo(({
             </p>
           ) : item.consumedBy.length > 1 && (
             <p className="text-xs text-zinc-500 dark:text-zinc-500 mt-1 transition-colors">
-              Each person pays: {formatCurrency((parseFloat(item.price) * item.quantity / item.consumedBy.length))}
+              Each person pays: {formatCurrency((itemPrice * item.quantity / item.consumedBy.length))}
             </p>
           )}
         </div>

--- a/src/Components/ItemsInput.jsx
+++ b/src/Components/ItemsInput.jsx
@@ -1,5 +1,5 @@
 import { useState, useRef, memo, useCallback, useEffect } from 'react';
-import useBillStore, { useBillItems } from '../billStore';
+import useBillStore, { useBillItems, getDiscountedItemPrice } from '../billStore';
 import { useFormatCurrency } from '../currencyStore';
 import { useShallow } from 'zustand/shallow';
 import { Button, Card } from '../ui/components';
@@ -19,7 +19,7 @@ const ItemForm = memo(({ onAddItem }) => {
   
   const handleSubmit = (e) => {
     e.preventDefault();
-    if (newItem.name.trim() && Number(newItem.price) > 0) {
+    if (newItem.name.trim() && newItem.price !== '' && !isNaN(Number(newItem.price))) {
       onAddItem({
         name: newItem.name.trim(),
         price: newItem.price,
@@ -65,7 +65,6 @@ const ItemForm = memo(({ onAddItem }) => {
           </label>
           <input
             type="number"
-            min="0"
             step="0.01"
             value={newItem.price}
             onChange={(e) => setNewItem({...newItem, price: e.target.value})}
@@ -124,7 +123,7 @@ const ItemListItem = memo(({ item, onRemove, onEdit, formatCurrency }) => {
         <span className="font-medium dark:text-white transition-colors">{item.name}</span>
         <span className="ml-2 text-sm text-zinc-600 dark:text-zinc-400 transition-colors">
           {item.quantity > 1 ? `${item.quantity} × ` : ''}
-          {formatCurrency(Number(item.price))}
+          {formatCurrency(getDiscountedItemPrice(item))}
         </span>
       </div>
       <div className="flex space-x-2">

--- a/src/Components/PassAndSplit/ItemCard.jsx
+++ b/src/Components/PassAndSplit/ItemCard.jsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect, useCallback } from 'react';
 import { useTheme } from '../../ThemeContext';
+import { getDiscountedItemPrice } from '../../billStore';
 
 const ItemCard = ({ 
   item, 
@@ -121,6 +122,8 @@ const ItemCard = ({
       : '0 10px 25px -5px rgba(0, 0, 0, 0.1), 0 10px 10px -5px rgba(0, 0, 0, 0.05)'
   };
   
+  const itemPrice = getDiscountedItemPrice(item);
+
   return (
     <div
       className="absolute w-full h-full rounded-xl"
@@ -136,10 +139,10 @@ const ItemCard = ({
           <h3 className="text-xl font-semibold truncate">{item.name}</h3>
           <div className="flex justify-between items-center mt-1">
             <span className="font-medium">
-              {formatCurrency(item.price)} × {item.quantity}
+              {formatCurrency(itemPrice)} × {item.quantity}
             </span>
             <span className="font-bold">
-              {formatCurrency(item.price * item.quantity)}
+              {formatCurrency(itemPrice * item.quantity)}
             </span>
           </div>
         </div>

--- a/src/billStore.js
+++ b/src/billStore.js
@@ -13,6 +13,16 @@ export const SPLIT_TYPES = {
 // Add version for future compatibility
 export const BILL_STORE_VERSION = '1.0.0';
 
+// Helper to apply item-level discounts
+export const getDiscountedItemPrice = (item) => {
+  const price = parseFloat(item.price) || 0;
+  const discount = parseFloat(item.discount) || 0;
+  if (item.discountType === 'percentage') {
+    return price - (price * discount) / 100;
+  }
+  return price - discount;
+};
+
 // Initial state with enhanced structure
 const initialState = {
   version: BILL_STORE_VERSION,
@@ -73,6 +83,8 @@ const useBillStore = create(
           name: item.name,
           price: parseFloat(item.price),
           quantity: parseInt(item.quantity) || 1,
+          discount: parseFloat(item.discount) || 0,
+          discountType: item.discountType || 'flat',
           consumedBy: [],
           splitType: SPLIT_TYPES.EQUAL // default split type
         }]
@@ -228,8 +240,9 @@ const useBillStore = create(
         state.items.forEach(item => {
           // Skip items with no consumers
           if (item.consumedBy.length === 0) return;
-          
-          const totalItemPrice = parseFloat(item.price) * item.quantity;
+
+          const itemPrice = getDiscountedItemPrice(item);
+          const totalItemPrice = itemPrice * item.quantity;
           
           // Calculate shares based on split type
           let shares = {};
@@ -295,12 +308,14 @@ const useBillStore = create(
               totals[personId].items.push({
                 id: item.id,
                 name: item.name,
-                price: parseFloat(item.price),
+                price: itemPrice,
                 quantity: item.quantity,
                 splitType: item.splitType,
                 allocation: allocation.value,
                 share: share,
-                sharedWith: item.consumedBy.length // Add count of people sharing this item
+                sharedWith: item.consumedBy.length,
+                discount: item.discount,
+                discountType: item.discountType
               });
               
               totals[personId].subtotal += share;
@@ -334,7 +349,7 @@ const useBillStore = create(
       getSubtotal: () => {
         const state = get();
         return state.items.reduce(
-          (sum, item) => sum + (parseFloat(item.price) * item.quantity), 
+          (sum, item) => sum + (getDiscountedItemPrice(item) * item.quantity),
           0
         );
       },

--- a/src/billStore.test.js
+++ b/src/billStore.test.js
@@ -594,6 +594,25 @@ describe('billStore - Calculation Functions', () => {
      expect(wendyTotal.items.find(i => i.id === items[1].id).share).toBeCloseTo(100);
   });
 
+  test('should apply item discounts in subtotal and person totals', () => {
+    const { addPerson, addItem, updateItem, assignItemEqual, getSubtotal, getPersonTotals } = useBillStore.getState();
+    act(() => {
+      addPerson('Discount Tester');
+      addItem({ name: 'Discounted', price: 100, quantity: 1 });
+    });
+    const state = useBillStore.getState();
+    const itemId = state.items[0].id;
+    const personId = state.people[0].id;
+    act(() => {
+      updateItem(itemId, { discount: 10, discountType: 'percentage' });
+      assignItemEqual(itemId, [personId]);
+    });
+    expect(getSubtotal()).toBeCloseTo(90);
+    const totals = getPersonTotals();
+    const personTotal = totals.find(p => p.id === personId);
+    expect(personTotal.subtotal).toBeCloseTo(90);
+  });
+
   test('should handle items with zero consumers in totals calculation', () => {
     const { people, items } = setupScenario();
     const { getPersonTotals, getGrandTotal } = useBillStore.getState();


### PR DESCRIPTION
## Summary
- allow negative item prices for manual discounts
- add item-level discount fields with flat or percentage options
- account for discounts across item listings and totals

## Testing
- `npm run lint` *(fails: various lint errors in repo)*
- `npm test` *(fails: TypeError - missing custom hooks)*

------
https://chatgpt.com/codex/tasks/task_e_68ab0eeaf0e8832596f84a24df864726