### PR TITLE
feat: add online status hook and offline handling for receipt scan

### DIFF
--- a/src/Components/ScanReceiptButton.jsx
+++ b/src/Components/ScanReceiptButton.jsx
@@ -2,6 +2,7 @@ import React, { useState, useRef, useEffect } from 'react';
 import useBillStore from '../billStore';
 import { useShallow } from 'zustand/shallow';
 import { Button, Modal, FileUpload, Spinner, Alert } from '../ui/components';
+import useOnlineStatus from '../hooks/useOnlineStatus';
 
 const API_URL = import.meta.env.VITE_WORKER_URL;
 
@@ -115,17 +116,24 @@ const ScanReceiptButton = () => {
       setTax: state.setTax
     }))
   );
-  
+
   const [isModalOpen, setIsModalOpen] = useState(false);
   const [isModeSelectionOpen, setIsModeSelectionOpen] = useState(false);
   const [isLoading, setIsLoading] = useState(false);
   const [error, setError] = useState(null);
   const [useCameraCapture, setUseCameraCapture] = useState(undefined);
+  const [isOfflineModalOpen, setIsOfflineModalOpen] = useState(false);
+
+  const isOnline = useOnlineStatus();
   
   // Single file input ref
   const fileInputRef = useRef(null);
 
   const openModal = () => {
+    if (!isOnline) {
+      setIsOfflineModalOpen(true);
+      return;
+    }
     setIsModalOpen(true);
     setError(null);
     setUseCameraCapture(undefined);
@@ -138,6 +146,10 @@ const ScanReceiptButton = () => {
     if (fileInputRef.current) {
       fileInputRef.current.value = '';
     }
+  };
+
+  const closeOfflineModal = () => {
+    setIsOfflineModalOpen(false);
   };
 
   const openModeSelection = () => {
@@ -303,12 +315,25 @@ const ScanReceiptButton = () => {
         />
       </Modal>
 
-      <ModeSelectionModal 
+      <ModeSelectionModal
         isOpen={isModeSelectionOpen}
         onClose={closeModeSelection}
         onSelectUpload={handleSelectUpload}
         onSelectCapture={handleSelectCapture}
       />
+
+      <Modal
+        isOpen={isOfflineModalOpen}
+        onClose={closeOfflineModal}
+        title="Offline"
+      >
+        <Alert type="warning">
+          <p>You are offline. Scan Receipt requires an internet connection.</p>
+        </Alert>
+        <div className="flex justify-end">
+          <Button onClick={closeOfflineModal}>OK</Button>
+        </div>
+      </Modal>
     </>
   );
 };

--- a/src/hooks/useOnlineStatus.js
+++ b/src/hooks/useOnlineStatus.js
@@ -1,0 +1,23 @@
+import { useState, useEffect } from 'react';
+
+// Hook to detect online/offline status
+const useOnlineStatus = () => {
+  const [isOnline, setIsOnline] = useState(navigator.onLine);
+
+  useEffect(() => {
+    const handleOnline = () => setIsOnline(true);
+    const handleOffline = () => setIsOnline(false);
+
+    window.addEventListener('online', handleOnline);
+    window.addEventListener('offline', handleOffline);
+
+    return () => {
+      window.removeEventListener('online', handleOnline);
+      window.removeEventListener('offline', handleOffline);
+    };
+  }, []);
+
+  return isOnline;
+};
+
+export default useOnlineStatus;


### PR DESCRIPTION
## Summary
- add `useOnlineStatus` hook for tracking navigator connectivity
- prevent scanning receipt while offline and show warning modal

## Testing
- `npm test` *(fails: useBillStep is not a function, useBillCurrency is not a function, useBillTitle is not a function, useBillTaxAmount is not a function, useBillSubtotal is not a function, useBillGrandTotal is not a function)*
- `npm run lint` *(fails: "test" is not defined, "expect" is not defined)*
- `npx eslint src/hooks/useOnlineStatus.js src/Components/ScanReceiptButton.jsx`


------
https://chatgpt.com/codex/tasks/task_e_68ab3986c4b08325b60190080e9b276d