### PR TITLE
Avoid overwriting unsaved bill data

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -195,19 +195,23 @@ const AppContent = () => {
   useDocumentTitle();
   // Check if we need to load the current bill from history
   const currentBill = useBillHistoryStore(state => state.getCurrentBill());
-  const { importBill, setBillId } = useBillStore(
+  const { importBill, billId, people, items } = useBillStore(
     useShallow(state => ({
       importBill: state.importBill,
-      setBillId: state.setBillId
+      billId: state.billId,
+      people: state.people,
+      items: state.items,
     }))
   );
-  
-  // Load current bill from history if it exists (only on initial load)
+
+  const hasBillData = billId || people.length > 0 || items.length > 0;
+
+  // Load current bill from history only if we don't already have bill data
   useEffect(() => {
-    if (currentBill) {
+    if (currentBill && !hasBillData) {
       importBill(currentBill.data);
     }
-  }, [currentBill, importBill, setBillId]);
+  }, [currentBill, importBill, hasBillData]);
   
   // Render the appropriate step
   const renderStep = () => {

--- a/src/billStore.js
+++ b/src/billStore.js
@@ -437,6 +437,10 @@ const useBillStore = create(
 // Custom selectors using useShallow to prevent infinite loops
 export const useBillPersons = () => useBillStore(useShallow(state => state.people));
 export const useBillItems = () => useBillStore(useShallow(state => state.items));
+export const useBillStep = () => useBillStore(state => state.step);
+export const useBillCurrency = () => useBillStore(state => state.currency);
+export const useBillTitle = () => useBillStore(state => state.title);
+export const useBillTaxAmount = () => useBillStore(state => state.taxAmount);
 
 // More complex selectors with derived data
 export const useBillPersonTotals = () => {
@@ -444,6 +448,16 @@ export const useBillPersonTotals = () => {
   const getPersonTotals = useBillStore(state => state.getPersonTotals);
   // Then call the function to get the current totals
   return getPersonTotals();
+};
+
+export const useBillSubtotal = () => {
+  const getSubtotal = useBillStore(state => state.getSubtotal);
+  return getSubtotal();
+};
+
+export const useBillGrandTotal = () => {
+  const getGrandTotal = useBillStore(state => state.getGrandTotal);
+  return getGrandTotal();
 };
 
 // Hook for updating document title based on bill title


### PR DESCRIPTION
## Summary
- Guard history import so bill state isn't overwritten when reopening the PWA
- Add missing selector hooks (step, currency, etc.) for bill store

## Testing
- `npm test`
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4a6614b883258f362cc963b7c478