### PR TITLE
feat: add settings page with currency selector

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -5,6 +5,7 @@ import PeopleInput from './Components/PeopleInput';
 import ItemsInput from './Components/ItemsInput';
 import ItemAssignment from './Components/ItemAssignment';
 import BillSummary from './Components/BillSummary';
+import Settings from './Components/Settings';
 import { Sidebar, HamburgerButton } from './Components/Sidebar';
 import useBillStore from './billStore';
 import useBillHistoryStore from './billHistoryStore';
@@ -96,6 +97,7 @@ const AppContent = () => {
   
   // Sidebar state
   const [isSidebarOpen, setIsSidebarOpen] = useState(false);
+  const [activeItemId, setActiveItemId] = useState(step);
   
   // Use local storage to remember sidebar state
   useEffect(() => {
@@ -109,6 +111,11 @@ const AppContent = () => {
   useEffect(() => {
     localStorage.setItem('sidebarOpen', JSON.stringify(isSidebarOpen));
   }, [isSidebarOpen]);
+
+  // Keep active sidebar item in sync with step changes
+  useEffect(() => {
+    setActiveItemId(step);
+  }, [step]);
   
   // Toggle sidebar
   const toggleSidebar = () => setIsSidebarOpen(!isSidebarOpen);
@@ -176,18 +183,14 @@ const AppContent = () => {
   
   // Handle sidebar item click
   const handleSidebarItemClick = (itemId) => {
-    // If it's a numeric ID, it's a step
     if (!isNaN(itemId)) {
-      goToStep(Number(itemId));
-    } else {
-      if(itemId === 'history') {
-        // Open the bill history modal  
-        openModal();
-      }
-      else {
-        alert(`${itemId} feature coming soon!`);
-      }
-      
+      const numericId = Number(itemId);
+      goToStep(numericId);
+      setActiveItemId(numericId);
+    } else if (itemId === 'history') {
+      openModal();
+    } else if (itemId === 'settings') {
+      setActiveItemId('settings');
     }
   };
   
@@ -228,15 +231,22 @@ const AppContent = () => {
         return <PeopleInput />;
     }
   };
+
+  const renderContent = () => {
+    if (activeItemId === 'settings') {
+      return <Settings />;
+    }
+    return renderStep();
+  };
   
   return (
     <div className="min-h-screen bg-zinc-100 dark:bg-zinc-900 transition-colors duration-200">
       {/* Sidebar */}
-      <Sidebar 
+      <Sidebar
         isOpen={isSidebarOpen}
         onToggle={toggleSidebar}
         items={sidebarItems}
-        activeItemId={step}
+        activeItemId={activeItemId}
         onItemClick={handleSidebarItemClick}
       />
       
@@ -247,8 +257,8 @@ const AppContent = () => {
         <div className="py-8 px-4">
           <div className="max-w-lg mx-auto bg-white dark:bg-zinc-800 p-6 rounded-xl shadow-lg ring-1 ring-zinc-200/50 dark:ring-zinc-700/50 transition-colors duration-200">
             <Header toggleSidebar={toggleSidebar} isSidebarOpen={isSidebarOpen} />
-            <StepIndicator />
-            {renderStep()}
+            {typeof activeItemId === 'number' && <StepIndicator />}
+            {renderContent()}
           </div>
         </div>
       </div>

--- a/src/Components/Settings.jsx
+++ b/src/Components/Settings.jsx
@@ -1,0 +1,71 @@
+import React, { useMemo } from 'react';
+import useCurrencyStore from '../currencyStore';
+import { useShallow } from 'zustand/shallow';
+
+const getCurrencySymbol = (code) => {
+  try {
+    return new Intl.NumberFormat(undefined, {
+      style: 'currency',
+      currency: code,
+      currencyDisplay: 'narrowSymbol',
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 0
+    })
+      .formatToParts(0)
+      .find(part => part.type === 'currency')
+      .value;
+  } catch {
+    return code;
+  }
+};
+
+const getCurrencyCodes = () => {
+  if (typeof Intl.supportedValuesOf === 'function') {
+    return Intl.supportedValuesOf('currency');
+  }
+  return [
+    'USD','EUR','GBP','JPY','CAD','AUD','CHF','CNY','SEK','NZD',
+    'MXN','SGD','HKD','NOK','KRW','TRY','RUB','INR','BRL','ZAR'
+  ];
+};
+
+const Settings = () => {
+  const { currency, changeCurrency } = useCurrencyStore(
+    useShallow(state => ({
+      currency: state.currency,
+      changeCurrency: state.changeCurrency
+    }))
+  );
+
+  const currencyOptions = useMemo(() => {
+    return getCurrencyCodes()
+      .map(code => ({ code, symbol: getCurrencySymbol(code) }))
+      .sort((a, b) => a.code.localeCompare(b.code));
+  }, []);
+
+  return (
+    <div className="space-y-4">
+      <h2 className="text-xl font-bold text-zinc-800 dark:text-white">Settings</h2>
+
+      <div>
+        <label className="block text-sm font-medium text-zinc-700 dark:text-zinc-300 mb-1">
+          Currency
+        </label>
+        <select
+          value={currency}
+          onChange={(e) => changeCurrency(e.target.value)}
+          className="w-full p-2 border rounded-md bg-white dark:bg-zinc-800 dark:text-white dark:border-zinc-600"
+        >
+          {currencyOptions.map(({ code, symbol }) => (
+            <option key={code} value={code}>
+              {code} ({symbol})
+            </option>
+          ))}
+        </select>
+      </div>
+    </div>
+  );
+};
+
+export default Settings;
+


### PR DESCRIPTION
## Summary
- add settings page to sidebar and hide step indicator when active
- let users choose currency using Intl API

## Testing
- `npm test`
- `npm run lint` *(fails: 'error is defined but never used', 'no-case-declarations', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68ab4d7fa1cc8325ac4a8f4ae4567c4a