### PR TITLE
Add UPI payment links and sharing

### DIFF
--- a/src/Components/BillSummary.jsx
+++ b/src/Components/BillSummary.jsx
@@ -1,11 +1,19 @@
-import { memo, useCallback } from 'react';
+import { memo, useCallback, useState } from 'react';
 import useBillStore, { useBillPersonTotals } from '../billStore';
 import useBillHistoryStore from '../billHistoryStore';
-import { useFormatCurrency } from '../currencyStore';
+import useCurrencyStore, { useFormatCurrency } from '../currencyStore';
 import { useShallow } from 'zustand/shallow';
 import { Button, Card, PrintButton, PrintWrapper } from '../ui/components';
 import BillTotalsSummary from './BillTotalsSummary';
 import { useBillHistory } from './BillHistory/BillHistoryContext';
+
+// Generate a UPI payment link
+function generateUpiLink({ upiId, amount, note }) {
+  let link = `upi://pay?pa=${encodeURIComponent(upiId)}&cu=INR`;
+  if (amount) link += `&am=${encodeURIComponent(amount)}`;
+  if (note) link += `&tn=${encodeURIComponent(note.substring(0, 80))}`;
+  return link;
+}
 
 // BillTitle component for displaying the title in summary view
 const BillTitle = memo(({ title }) => {
@@ -38,13 +46,57 @@ const PersonItemRow = memo(({ item, formatCurrency }) => {
 });
 
 // PersonCard component for each person's summary
-const PersonCard = memo(({ person, formatCurrency }) => {
+const PersonCard = memo(({ person, formatCurrency, upiId, billTitle }) => {
+  const upiLink = upiId
+    ? generateUpiLink({
+        upiId,
+        amount: person.total.toFixed(2),
+        note: `${person.name}${billTitle ? ' - ' + billTitle : ''}`,
+      })
+    : null;
+
+  const handleShare = async () => {
+    const text = `${person.name} owes ${formatCurrency(person.total)}${
+      billTitle ? ` for ${billTitle}` : ''
+    }${upiLink ? `\nPay: ${upiLink}` : ''}`;
+    try {
+      if (navigator.share) {
+        await navigator.share({ title: billTitle || 'Bill Payment', text, url: upiLink || undefined });
+      } else if (navigator.clipboard) {
+        await navigator.clipboard.writeText(text);
+        alert('Payment details copied to clipboard');
+      }
+    } catch (err) {
+      // ignore
+    }
+  };
+
   return (
     <Card>
-      <h3 className="text-lg font-bold mb-3 pb-2 border-b border-zinc-100 dark:border-zinc-700 text-zinc-800 dark:text-white transition-colors">
-        {person.name}
-      </h3>
-      
+      <div className="flex justify-between items-center mb-3 pb-2 border-b border-zinc-100 dark:border-zinc-700">
+        <h3 className="text-lg font-bold text-zinc-800 dark:text-white transition-colors">
+          {person.name}
+        </h3>
+        <div className="flex items-center gap-2">
+          {upiLink && (
+            <a
+              href={upiLink}
+              className="text-blue-600 dark:text-blue-400 underline text-sm"
+            >
+              Pay
+            </a>
+          )}
+          <Button
+            size="sm"
+            variant="secondary"
+            onClick={handleShare}
+            className="no-print"
+          >
+            Share
+          </Button>
+        </div>
+      </div>
+
       {person.items.length > 0 ? (
         <>
           <ul className="mb-4 space-y-1 divide-y divide-zinc-100 dark:divide-zinc-700 transition-colors">
@@ -56,20 +108,20 @@ const PersonCard = memo(({ person, formatCurrency }) => {
               />
             ))}
           </ul>
-          
+
           <div className="border-t border-zinc-100 dark:border-zinc-700 pt-3 space-y-1 transition-colors">
             <div className="flex justify-between">
               <span className="text-zinc-700 dark:text-zinc-300 transition-colors">Subtotal:</span>
               <span className="text-zinc-700 dark:text-zinc-300 transition-colors">{formatCurrency(person.subtotal)}</span>
             </div>
-            
+
             {person.tax > 0 && (
               <div className="flex justify-between">
                 <span className="text-zinc-700 dark:text-zinc-300 transition-colors">Tax:</span>
                 <span className="text-zinc-700 dark:text-zinc-300 transition-colors">{formatCurrency(person.tax)}</span>
               </div>
             )}
-            
+
             <div className="flex justify-between font-bold text-lg pt-1">
               <span className="text-zinc-900 dark:text-white transition-colors">Total:</span>
               <span className="text-zinc-900 dark:text-white transition-colors">{formatCurrency(person.total)}</span>
@@ -86,7 +138,7 @@ const PersonCard = memo(({ person, formatCurrency }) => {
 // EditButtons component for navigation
 const EditButtons = memo(({ onEdit }) => {
   return (
-    <div className="space-x-4 space-y-4 mb-4 no-print">
+    <div className="space-x-4 space-y-4 no-print">
       <Button
         variant="secondary"
         size="sm"
@@ -133,10 +185,18 @@ const BillSummary = () => {
   );
   
   const formatCurrency = useFormatCurrency();
-  
+
+  // Current currency
+  const currency = useCurrencyStore(state => state.currency);
+
   // Get bill history modal controls
   const { openModal } = useBillHistory();
-  
+
+  // User provided UPI ID
+  const [upiId, setUpiId] = useState('');
+  const [showUpiInput, setShowUpiInput] = useState(false);
+  const isInr = currency === 'INR';
+
   // Get person totals using the specialized hook
   const personTotals = useBillPersonTotals();
   
@@ -200,17 +260,54 @@ const BillSummary = () => {
   return (
     <div>
       <h2 className="text-xl font-semibold mb-4 text-zinc-800 dark:text-white transition-colors">Bill Summary</h2>
-      
+      {isInr && (
+        <div className="mb-4">
+          {showUpiInput ? (
+            <div className="flex items-center gap-2 no-print">
+              <input
+                type="text"
+                value={upiId}
+                onChange={e => setUpiId(e.target.value)}
+                placeholder="your-upi@bank"
+                className="flex-1 p-2 border border-zinc-300 dark:border-zinc-600 rounded-md"
+              />
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setShowUpiInput(false)}
+              >
+                Hide
+              </Button>
+            </div>
+          ) : (
+            <div className="flex items-center gap-2 no-print">
+              {upiId && (
+                <span className="text-zinc-800 dark:text-white">UPI ID: {upiId}</span>
+              )}
+              <Button
+                size="sm"
+                variant="secondary"
+                onClick={() => setShowUpiInput(true)}
+              >
+                {upiId ? 'Edit UPI ID' : 'Add UPI ID'}
+              </Button>
+            </div>
+          )}
+        </div>
+      )}
+
       <PrintWrapper>
         <div id="printable-bill">
           {/* Display bill title in printable section */}
           <BillTitle title={title} />
-          
+
           {personTotals.map(person => (
-            <PersonCard 
+            <PersonCard
               key={person.id}
               person={person}
               formatCurrency={formatCurrency}
+              upiId={isInr ? upiId : ''}
+              billTitle={title}
             />
           ))}
           
@@ -224,33 +321,45 @@ const BillSummary = () => {
         </div>
       </PrintWrapper>
       
-      <div className="flex flex-wrap justify-between items-center no-print">
-        <EditButtons onEdit={handleEdit} />
-        
-        <div className="space-x-2 mb-4 flex flex-wrap gap-2">
-          <PrintButton onClick={handlePrint} />
-          
-          <Button
-            variant="success"
-            onClick={handleSaveBill}
-          >
-            Save Bill
-          </Button>
-          
-          <Button
-            variant="secondary"
-            onClick={handleExportJson}
-          >
-            Export JSON
-          </Button>
-          
+      <div className="no-print space-y-6">
+        <div>
+          <h3 className="text-lg font-semibold text-zinc-800 dark:text-white mb-2">Edit</h3>
+          <EditButtons onEdit={handleEdit} />
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold text-zinc-800 dark:text-white mb-2">Bill Actions</h3>
+          <div className="flex flex-wrap gap-2">
+            <PrintButton onClick={handlePrint} />
+
+            <Button
+              variant="success"
+              onClick={handleSaveBill}
+            >
+              Save Bill
+            </Button>
+
+            <Button
+              variant="secondary"
+              onClick={handleExportJson}
+            >
+              Export JSON
+            </Button>
+          </div>
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold text-zinc-800 dark:text-white mb-2">History</h3>
           <Button
             variant="secondary"
             onClick={openModal}
           >
             Bill History
           </Button>
-          
+        </div>
+
+        <div>
+          <h3 className="text-lg font-semibold text-zinc-800 dark:text-white mb-2">Reset</h3>
           <Button
             variant="danger"
             onClick={handleReset}


### PR DESCRIPTION
## Summary
- streamline UPI link generation and add payer name to note
- show UPI ID option only when currency is INR
- group summary page actions with headers for clarity

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68ab504093748325866b48c9e03cffb5