### PR TITLE
feat: show discount details and share UPI ID

### DIFF
--- a/src/Components/BillTotalsSummary.jsx
+++ b/src/Components/BillTotalsSummary.jsx
@@ -23,9 +23,9 @@ const BillTotalsSummary = memo(({
           {formatCurrency(taxAmount)}
         </span>
       </div>
-      <div className="flex justify-between items-center font-bold text-lg pt-2 border-t border-zinc-200 dark:border-zinc-600">
-        <span className="text-zinc-900 dark:text-white transition-colors">Grand Total:</span>
-        <span className="text-zinc-900 dark:text-white transition-colors">
+      <div className="flex justify-between items-center font-bold text-lg pt-2 border-t border-zinc-200 dark:border-zinc-600 px-2 py-1 bg-green-100 text-green-800 dark:bg-green-800 dark:text-green-100 print:bg-green-800 print:text-white rounded transition-colors">
+        <span>Grand Total:</span>
+        <span>
           {formatCurrency(grandTotal)}
         </span>
       </div>

--- a/src/Components/ItemAssignment.jsx
+++ b/src/Components/ItemAssignment.jsx
@@ -98,6 +98,14 @@ const ItemCard = memo(({
   }, [onTogglePerson, item.id]);
   
   const itemPrice = useMemo(() => getDiscountedItemPrice(item), [item]);
+  const hasDiscount = item.discount > 0;
+  const discountText = hasDiscount
+    ? `Discount ${
+        item.discountType === 'percentage'
+          ? `${item.discount}%`
+          : formatCurrency(item.discount)
+      }`
+    : '';
 
   return (
     <Card className="mb-4">
@@ -107,6 +115,11 @@ const ItemCard = memo(({
           <p className="text-sm text-zinc-600 dark:text-zinc-400 transition-colors">
             {item.quantity > 1 ? `${item.quantity} × ` : ''}
             {formatCurrency(itemPrice)}
+            {hasDiscount && (
+              <span className="ml-1 text-xs text-zinc-500 dark:text-zinc-400 transition-colors">
+                ({discountText})
+              </span>
+            )}
           </p>
         </div>
         <button 
@@ -315,10 +328,12 @@ const ItemAssignment = () => {
       case SPLIT_TYPES.FRACTION:
         assignItemFraction(itemId, allocations);
         break;
-      default:
+      default: {
         // For equal split, we need to extract just the personIds
         const personIds = allocations.map(a => a.id);
         assignItemEqual(itemId, personIds);
+        break;
+      }
     }
   }, [setSplitType, assignItemPercentage, assignItemFraction, assignItemEqual]);
   

--- a/src/Components/ItemsInput.jsx
+++ b/src/Components/ItemsInput.jsx
@@ -112,11 +112,20 @@ const ItemListItem = memo(({ item, onRemove, onEdit, formatCurrency }) => {
   const handleRemove = useCallback(() => {
     onRemove(item.id);
   }, [item.id, onRemove]);
-  
+
   const handleEdit = useCallback(() => {
     onEdit(item);
   }, [item, onEdit]);
-  
+
+  const hasDiscount = item.discount > 0;
+  const discountText = hasDiscount
+    ? `Discount ${
+        item.discountType === 'percentage'
+          ? `${item.discount}%`
+          : formatCurrency(item.discount)
+      }`
+    : '';
+
   return (
     <li className="flex justify-between items-center p-2 bg-zinc-50 dark:bg-zinc-700 rounded-md border border-zinc-200 dark:border-zinc-600 shadow-sm transition-colors">
       <div>
@@ -125,9 +134,14 @@ const ItemListItem = memo(({ item, onRemove, onEdit, formatCurrency }) => {
           {item.quantity > 1 ? `${item.quantity} × ` : ''}
           {formatCurrency(getDiscountedItemPrice(item))}
         </span>
+        {hasDiscount && (
+          <span className="block text-xs text-zinc-500 dark:text-zinc-400 transition-colors">
+            ({discountText})
+          </span>
+        )}
       </div>
       <div className="flex space-x-2">
-        <button 
+        <button
           onClick={handleEdit}
           className="text-blue-500 dark:text-blue-400 hover:text-blue-700 dark:hover:text-blue-300 focus:outline-none focus-visible:ring-2 focus-visible:ring-blue-500 dark:focus-visible:ring-blue-400 focus-visible:ring-offset-1 dark:focus-visible:ring-offset-zinc-800 rounded-full transition-colors"
           aria-label={`Edit ${item.name}`}


### PR DESCRIPTION
## Summary
- display item discounts throughout the app
- remove pay link, share UPI ID text with itemized breakdown
- style totals with dark green background in print

## Testing
- `npm run lint` *(fails: 'expect' is not defined, etc.)*
- `npx eslint src/Components/BillSummary.jsx src/Components/BillTotalsSummary.jsx src/Components/ItemsInput.jsx src/Components/ItemAssignment.jsx`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68abd93fe20483259a540ebc04a04536