### PR TITLE
Add PWA update prompt and bump version to 1.1.0

### DIFF
--- a/changes/2025_08_25_pwa_update_prompt.md
+++ b/changes/2025_08_25_pwa_update_prompt.md
@@ -1,0 +1,5 @@
+# PWA update prompt and offline support
+
+- Bumped app version to 1.1.0.
+- Added service worker prompt to notify users of updates and offline readiness.
+- Switched PWA registration to prompt mode.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "billsplitter",
-  "version": "0.0.0",
+  "version": "1.1.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "billsplitter",
-      "version": "0.0.0",
+      "version": "1.1.0",
       "dependencies": {
         "@tailwindcss/vite": "^4.0.10",
         "react": "^19.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "billsplitter",
   "private": true,
-  "version": "0.0.0",
+  "version": "1.1.0",
   "type": "module",
   "scripts": {
     "lint": "eslint .",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -12,6 +12,7 @@ import useBillHistoryStore from './billHistoryStore';
 import { useDocumentTitle } from './billStore';
 import { useShallow } from 'zustand/shallow';
 import { BillHistoryProvider, useBillHistory } from './Components/BillHistory/BillHistoryContext';
+import ServiceWorkerPrompt from './Components/Prompts/ServiceWorkerPrompt';
 import './App.css';
 
 // StepIndicator component 
@@ -272,6 +273,7 @@ const App = () => {
     <ThemeProvider>
       <BillHistoryProvider>
         <AppContent />
+        <ServiceWorkerPrompt />
       </BillHistoryProvider>
     </ThemeProvider>
   );

--- a/src/Components/Prompts/ServiceWorkerPrompt.tsx
+++ b/src/Components/Prompts/ServiceWorkerPrompt.tsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import { useRegisterSW } from 'virtual:pwa-register/react';
+
+const ServiceWorkerPrompt = () => {
+  const {
+    offlineReady: [offlineReady, setOfflineReady],
+    needRefresh: [needRefresh, setNeedRefresh],
+    updateServiceWorker,
+  } = useRegisterSW();
+
+  const close = () => {
+    setOfflineReady(false);
+    setNeedRefresh(false);
+  };
+
+  if (!offlineReady && !needRefresh) {
+    return null;
+  }
+
+  return (
+    <div className="fixed bottom-4 left-1/2 -translate-x-1/2 z-50">
+      <div className="flex items-center gap-2 bg-white dark:bg-zinc-800 text-zinc-800 dark:text-white px-4 py-3 rounded shadow-lg">
+        <span className="text-sm">
+          {offlineReady ? 'App ready to work offline' : 'New version available'}
+        </span>
+        {needRefresh && (
+          <button
+            className="px-2 py-1 text-sm bg-blue-500 text-white rounded"
+            onClick={() => updateServiceWorker(true)}
+          >
+            Reload
+          </button>
+        )}
+        <button
+          className="px-2 py-1 text-sm bg-zinc-200 dark:bg-zinc-700 rounded"
+          onClick={close}
+        >
+          Close
+        </button>
+      </div>
+    </div>
+  );
+};
+
+export default ServiceWorkerPrompt;

--- a/src/Components/Sidebar/Sidebar.jsx
+++ b/src/Components/Sidebar/Sidebar.jsx
@@ -102,7 +102,7 @@ const Sidebar = ({
           </nav>
           
           <div className={`mt-auto text-center transition-opacity duration-200 ${isOpen ? 'opacity-100' : 'opacity-0'}`}>
-            <p className="text-xs text-zinc-500">Version 1.0.0</p>
+            <p className="text-xs text-zinc-500">Version 1.1.0</p>
           </div>
         </div>
       </aside>

--- a/src/billHistoryStore.js
+++ b/src/billHistoryStore.js
@@ -2,7 +2,7 @@ import { create } from 'zustand';
 import { persist } from 'zustand/middleware';
 
 // Current version of bill history store
-export const BILL_HISTORY_VERSION = '1.0.0';
+export const BILL_HISTORY_VERSION = '1.1.0';
 
 // Function to generate 5-digit alphanumeric ID
 const generateBillId = () => {

--- a/src/billStore.js
+++ b/src/billStore.js
@@ -11,7 +11,7 @@ export const SPLIT_TYPES = {
 };
 
 // Add version for future compatibility
-export const BILL_STORE_VERSION = '1.0.0';
+export const BILL_STORE_VERSION = '1.1.0';
 
 // Helper to apply item-level discounts
 export const getDiscountedItemPrice = (item) => {

--- a/vite.config.js
+++ b/vite.config.js
@@ -6,7 +6,7 @@ import  { VitePWA }  from 'vite-plugin-pwa'
 export default defineConfig({
   plugins: [react(), tailwindcss(),VitePWA({
     base: '/BillSplitter/', // Match the base path
-    registerType: 'autoUpdate',
+    registerType: 'prompt',
     includeAssets: ['favicon.ico', 'robots.txt', 'icons/*.png'],
     manifest: {
       name: 'Bill Splitter',


### PR DESCRIPTION
## Summary
- bump application and store versions to 1.1.0
- add service worker prompt component for offline readiness and updates
- use prompt-based PWA registration for explicit refresh control

## Testing
- `npm test`
- `npm run lint` *(fails: numerous pre-existing lint errors)*

------
https://chatgpt.com/codex/tasks/task_e_68abde19c71c8325bc844cdcd2d070e8